### PR TITLE
refactor: Centralize template path constants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,9 +446,12 @@ Migration.migrate() {
 ### Template Loading
 **`scripts/blades-templates.js`** - Preloads all partials in `templates/parts/`
 
-Templates are referenced by path relative to module root:
+Templates are centralized in `scripts/constants.js`:
 ```javascript
-"modules/bitd-alternate-sheets/templates/actor-sheet.html"
+import { TEMPLATES } from "./constants.js";
+
+// Sheet templates use constants
+template: TEMPLATES.ACTOR_SHEET
 ```
 
 ### Custom Helpers
@@ -529,19 +532,21 @@ const { BladesSheet } = await import(
 
 **Action**: Remove commented imports or uncomment if needed.
 
-### 🟢 LOW: Template Path Hardcoding
+### ✅ COMPLETED: Template Path Constants
 
-**Current**:
+**Status**: Completed (2025-12-31)
+
+**Implementation**: Template paths are now centralized in `scripts/constants.js`:
 ```javascript
-template: "modules/bitd-alternate-sheets/templates/actor-sheet.html"
+import { TEMPLATES } from "./constants.js";
+
+// Sheet classes use constants
+template: TEMPLATES.ACTOR_SHEET
 ```
 
-**Could use**:
-```javascript
-template: `modules/${MODULE_ID}/templates/actor-sheet.html`
-```
+**Files**: `scripts/constants.js`, all sheet classes, `blades-templates.js`
 
-**Benefit**: Single source of truth for module ID (already defined in `utils.js`).
+**Benefit**: Single source of truth for template paths, easier refactoring.
 
 ---
 

--- a/docs/tracking/REMAINING_REFACTORINGS.md
+++ b/docs/tracking/REMAINING_REFACTORINGS.md
@@ -10,15 +10,15 @@
 
 These are **optional quality improvements** deferred from the main refactoring work. All high-priority (H1-H4) and medium-priority (M1-M8) items have been completed, plus L1 (break up `getVirtualListOfItems`).
 
-**Remaining:** 4 low-priority tasks
-**Total Estimated Effort:** ~4 hours 15 minutes
+**Remaining:** 3 low-priority tasks (L4 completed)
+**Total Estimated Effort:** ~3 hours 45 minutes
 **Impact:** Code quality and maintainability (not blocking functionality)
 
 | ID | Task | Effort | Priority | Status |
 |----|------|--------|----------|--------|
 | L2 | Standardize error handling patterns | 45 min | Low | ⬜ Not started |
 | L3 | Add JSDoc type annotations | 1 hour | Low | ⬜ Not started |
-| L4 | Centralize template path constants | 30 min | Low | ⬜ Not started |
+| L4 | Centralize template path constants | 30 min | Low | ✅ Completed (2025-12-31) |
 | L5 | Extract sheet state management | 2 hours | Very Low | ⬜ Not started |
 
 ---
@@ -377,7 +377,7 @@ Update this section when implementing tasks:
 
 - [ ] **L2:** Standardize error handling patterns
 - [ ] **L3:** Add JSDoc type annotations
-- [ ] **L4:** Centralize template path constants
+- [x] **L4:** Centralize template path constants (✅ 2025-12-31)
 - [ ] **L5:** Extract sheet state management
 
 ---

--- a/scripts/blades-alternate-actor-sheet.js
+++ b/scripts/blades-alternate-actor-sheet.js
@@ -1,6 +1,7 @@
 import { BladesSheet } from "../../../systems/blades-in-the-dark/module/blades-sheet.js";
 import { BladesActiveEffect } from "../../../systems/blades-in-the-dark/module/blades-active-effect.js";
 import { Utils, MODULE_ID } from "./utils.js";
+import { TEMPLATES } from "./constants.js";
 import { Profiler } from "./profiler.js";
 import { queueUpdate } from "./lib/update-queue.js";
 import { openCrewSelectionDialog, openCardSelectionDialog, confirmDialog } from "./lib/dialog-compat.js";
@@ -42,7 +43,7 @@ export class BladesAlternateActorSheet extends BladesSheet {
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["blades-alt", "sheet", "pc", "actor"],
-      template: "modules/bitd-alternate-sheets/templates/actor-sheet.html",
+      template: TEMPLATES.ACTOR_SHEET,
       width: 800,
       height: 1200,
       tabs: [

--- a/scripts/blades-alternate-class-sheet.js
+++ b/scripts/blades-alternate-class-sheet.js
@@ -1,5 +1,6 @@
 import { BladesActiveEffect } from "../../../systems/blades-in-the-dark/module/blades-active-effect.js";
 import { Utils, MODULE_ID } from "./utils.js";
+import { TEMPLATES } from "./constants.js";
 import { queueUpdate } from "./lib/update-queue.js";
 import { getItemSheetClass } from "./compat.js";
 import { guardDropAndHandle, setLocalPropAndRender, sheetDefaultOptions } from "./lib/sheet-helpers.js";
@@ -15,7 +16,7 @@ export class BladesAlternateClassSheet extends BaseItemSheet {
   static get defaultOptions() {
     return sheetDefaultOptions(super.defaultOptions, {
       classes: ["blades-alt", "sheet", "item", "class"],
-      template: "modules/bitd-alternate-sheets/templates/class-sheet.html",
+      template: TEMPLATES.CLASS_SHEET,
       width: 600,
       height: 600,
     });

--- a/scripts/blades-alternate-crew-sheet.js
+++ b/scripts/blades-alternate-crew-sheet.js
@@ -1,5 +1,6 @@
 import { BladesCrewSheet as SystemCrewSheet } from "../../../systems/blades-in-the-dark/module/blades-crew-sheet.js";
 import { Utils, MODULE_ID } from "./utils.js";
+import { TEMPLATES } from "./constants.js";
 import { Profiler } from "./profiler.js";
 import { bindInlineInputHandlers } from "./lib/sheet-helpers.js";
 
@@ -14,7 +15,7 @@ export class BladesAlternateCrewSheet extends SystemCrewSheet {
     const baseClasses = super.defaultOptions?.classes ?? [];
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: [...new Set([...baseClasses, "blades-alt"])],
-      template: "modules/bitd-alternate-sheets/templates/crew-sheet.html",
+      template: TEMPLATES.CREW_SHEET,
       width: 940,
       height: 940,
       tabs: [

--- a/scripts/blades-alternate-item-sheet.js
+++ b/scripts/blades-alternate-item-sheet.js
@@ -1,4 +1,5 @@
 import { Utils, MODULE_ID } from "./utils.js";
+import { TEMPLATES } from "./constants.js";
 import { queueUpdate } from "./lib/update-queue.js";
 import { getItemSheetClass } from "./compat.js";
 import { guardDropAndHandle, setLocalPropAndRender, sheetDefaultOptions } from "./lib/sheet-helpers.js";
@@ -14,7 +15,7 @@ export class BladesAlternateItemSheet extends BaseItemSheet {
   static get defaultOptions() {
     return sheetDefaultOptions(super.defaultOptions, {
       classes: ["blades-alt", "sheet", "item"],
-      template: "modules/bitd-alternate-sheets/templates/item-sheet.html",
+      template: TEMPLATES.ITEM_SHEET,
       width: 400,
       height: 600,
     });

--- a/scripts/blades-templates.js
+++ b/scripts/blades-templates.js
@@ -1,4 +1,5 @@
 import { loadTemplatesCompat } from "./compat-helpers.js";
+import { TEMPLATE_PARTS_PATH, TEMPLATE_PARTS } from "./constants.js";
 
 /**
  * Define a set of template paths to pre-load
@@ -6,30 +7,10 @@ import { loadTemplatesCompat } from "./compat-helpers.js";
  * @return {}
  */
 export const preloadHandlebarsTemplates = function () {
-  // Define template paths to load
-  const templatePaths = [
-    // Actor Sheet Partials
-    "modules/bitd-alternate-sheets/templates/parts/coins.html",
-    "modules/bitd-alternate-sheets/templates/parts/attributes.html",
-    "modules/bitd-alternate-sheets/templates/parts/xp-tracks.html",
-    "modules/bitd-alternate-sheets/templates/parts/harm.html",
-    "modules/bitd-alternate-sheets/templates/parts/load.html",
-    "modules/bitd-alternate-sheets/templates/parts/radiotoggles.html",
-    "modules/bitd-alternate-sheets/templates/parts/ability.html",
-    "modules/bitd-alternate-sheets/templates/parts/item.html",
-    "modules/bitd-alternate-sheets/templates/parts/item-list-section.html",
-    "modules/bitd-alternate-sheets/templates/parts/item-header.html",
-    "modules/bitd-alternate-sheets/templates/parts/dock-section.html",
-    "modules/bitd-alternate-sheets/templates/parts/crew-ability.html",
-    "modules/bitd-alternate-sheets/templates/parts/crew-upgrade.html",
-    "modules/bitd-alternate-sheets/templates/parts/turf-list.html",
-    "modules/bitd-alternate-sheets/templates/parts/section-controls.html",
-    "modules/bitd-alternate-sheets/templates/parts/acquaintance-body.html",
-    // "modules/bitd-alternate-sheets/templates/parts/cohort-block.html",
-    // "modules/bitd-alternate-sheets/templates/parts/factions.html",
-    "modules/bitd-alternate-sheets/templates/parts/active-effects.html",
-    "modules/bitd-alternate-sheets/templates/parts/identity-header.html",
-  ];
+  // Build full paths from TEMPLATE_PARTS constant
+  const templatePaths = TEMPLATE_PARTS.map(
+    (partialName) => `${TEMPLATE_PARTS_PATH}/${partialName}`
+  );
 
   // Load the template parts
   return loadTemplatesCompat(templatePaths);

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,43 @@
+import { MODULE_ID } from "./utils.js";
+
+/**
+ * Template path constants for the module.
+ * Single source of truth for all template file paths.
+ */
+
+export const TEMPLATES = {
+  ACTOR_SHEET: `modules/${MODULE_ID}/templates/actor-sheet.html`,
+  CREW_SHEET: `modules/${MODULE_ID}/templates/crew-sheet.html`,
+  CLASS_SHEET: `modules/${MODULE_ID}/templates/class-sheet.html`,
+  ITEM_SHEET: `modules/${MODULE_ID}/templates/item-sheet.html`,
+};
+
+export const TEMPLATE_PARTS_PATH = `modules/${MODULE_ID}/templates/parts`;
+
+/**
+ * Template part paths for preloading.
+ * Used by blades-templates.js for Handlebars partial registration.
+ */
+export const TEMPLATE_PARTS = [
+  // Actor Sheet Partials
+  "coins.html",
+  "attributes.html",
+  "xp-tracks.html",
+  "harm.html",
+  "load.html",
+  "radiotoggles.html",
+  "ability.html",
+  "item.html",
+  "item-list-section.html",
+  "item-header.html",
+  "dock-section.html",
+  "crew-ability.html",
+  "crew-upgrade.html",
+  "turf-list.html",
+  "section-controls.html",
+  "acquaintance-body.html",
+  // "cohort-block.html",
+  // "factions.html",
+  "active-effects.html",
+  "identity-header.html",
+];

--- a/skills/git-branching-strategy/SKILL.md
+++ b/skills/git-branching-strategy/SKILL.md
@@ -382,6 +382,37 @@ git checkout rc-1.1.0
 # Make changes
 git commit -m "docs: update contributing guidelines"
 git push origin rc-1.1.0
+
+# CRITICAL: Push to upstream BEFORE creating feature branches
+git push upstream rc-1.1.0
+```
+
+**⚠️ Why push to upstream immediately?**
+
+If you make direct commits to rc-1.1.0 locally, then create a feature branch, that feature branch will include your unpushed rc-1.1.0 commits. This creates messy PRs with unrelated changes.
+
+**Example of what goes wrong:**
+```bash
+# You commit docs directly to rc-1.1.0
+git checkout rc-1.1.0
+git commit -m "docs: add skills"
+# ❌ MISTAKE: Didn't push to upstream yet
+
+# You create a feature branch
+git checkout -b feat/new-feature
+# ... work on feature ...
+git push origin feat/new-feature
+
+# ❌ PROBLEM: Your feature PR now includes the doc commits!
+```
+
+**Fix:** Always push rc-1.1.0 to upstream before branching:
+```bash
+# After committing to rc-1.1.0:
+git push upstream rc-1.1.0    # ← Don't skip this!
+
+# Then create feature branches
+git checkout -b feat/new-feature
 ```
 
 **Option B: Feature branch + PR (if larger)**
@@ -389,11 +420,11 @@ git push origin rc-1.1.0
 git checkout -b docs/descriptive-name
 # Make changes
 git push origin docs/descriptive-name
-gh pr create --base rc-1.1.0
+gh pr create --repo ImproperSubset/foundry-bitd-alternate-sheets --base rc-1.1.0
 ```
 
 **Rule of thumb:**
-- README fixes, typo corrections → Direct commit OK
+- README fixes, typo corrections → Direct commit OK (push to upstream immediately)
 - New documentation sections, skills, guides → Feature branch + PR
 
 ## Commit Message Conventions

--- a/skills/git-branching-strategy/SKILL.md
+++ b/skills/git-branching-strategy/SKILL.md
@@ -300,8 +300,10 @@ git commit --amend
 ```bash
 git push origin feat/descriptive-name
 
-# Create PR to rc-1.1.0
-gh pr create --base rc-1.1.0 \
+# Create PR to rc-1.1.0 (in fork)
+# IMPORTANT: Specify --repo for fork workflows
+gh pr create --repo ImproperSubset/foundry-bitd-alternate-sheets \
+  --base rc-1.1.0 \
   --title "feat: Add descriptive feature" \
   --body "$(cat <<'EOF'
 ## Summary
@@ -313,6 +315,12 @@ gh pr create --base rc-1.1.0 \
 - [ ] Test case 2
 EOF
 )"
+
+# Alternative: PR directly to upstream (less common)
+# gh pr create --repo justinross/foundry-bitd-alternate-sheets \
+#   --base rc-1.1.0 \
+#   --head ImproperSubset:feat/descriptive-name \
+#   --title "feat: Add descriptive feature"
 ```
 
 ### 7. After Merge
@@ -353,11 +361,18 @@ Branches:
 3. Push to your fork
    git push origin feat/my-feature
 
-4. PR to upstream rc-1.1.0
-   gh pr create --base rc-1.1.0
+4. PR to fork's rc-1.1.0 (IMPORTANT: specify --repo)
+   gh pr create --repo ImproperSubset/foundry-bitd-alternate-sheets \
+     --base rc-1.1.0
 
-5. After merge, rc-1.1.0 → master (release)
+5. After merge in fork, sync with upstream
+   git checkout rc-1.1.0
+   git pull origin rc-1.1.0
+
+6. Later: rc-1.1.0 → master (release)
 ```
+
+**Why specify --repo?** In fork workflows, `gh pr create` defaults to the upstream repo, but your feature branch only exists in your fork (origin). Explicitly specifying `--repo` creates the PR in the correct location.
 
 ### Documentation-Only Changes
 


### PR DESCRIPTION
## Summary
- Extract all template paths to `scripts/constants.js`
- Update all sheet classes to use `TEMPLATES` constants
- Simplify `blades-templates.js` using `TEMPLATE_PARTS` array
- Complete L4 from REMAINING_REFACTORINGS.md

## Benefits
- Single source of truth for template paths
- Easier to refactor template directory structure
- Eliminates string duplication

## Testing
- CSS build passed
- No functional changes (paths remain identical)

Closes L4 from docs/tracking/REMAINING_REFACTORINGS.md